### PR TITLE
feat(django): add django 4.2 support, drop django 2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9']
-        django-version: ['master', '2.0', '2.1', '2.2', '3.0', '3.1', '3.2', '4.0']
+        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        django-version: ['master', '2.1', '2.2', '3.0', '3.1', '3.2', '4.0']
         exclude:
           - python-version: '3.8'
             django-version: '2.0'
@@ -41,13 +41,22 @@ jobs:
           - python-version: '3.7'
             django-version: '4.0'
 
-          - python-version: '3.5'
-            django-version: 'master'
-          - python-version: '3.6'
-            django-version: 'master'
-          - python-version: '3.7'
-            django-version: 'master'
           - python-version: '3.8'
+            django-version: '4.2'
+          - python-version: '3.9'
+            django-version: '4.2'
+          - python-version: '3.10'
+            django-version: '4.2'
+          - python-version: '3.11'
+            django-version: '4.2'
+
+          - python-version: '3.8'
+            django-version: 'master'
+          - python-version: '3.9'
+            django-version: 'master'
+          - python-version: '3.10'
+            django-version: 'master'
+          - python-version: '3.11'
             django-version: 'master'
 
     steps:

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,17 @@
+3.0.0 (2023-08-15)
+******************
+
+Backwards incompatible changes
+------------------------------
+
+- Raised the minimum required Django version to 2.1.
+
+Note worthy changes
+-------------------
+
+- Compatibility with Django 4.2.
+
+
 2.0.1 (2022-03-29)
 ******************
 

--- a/actistream/__init__.py
+++ b/actistream/__init__.py
@@ -1,6 +1,6 @@
 from importlib import import_module
 
-VERSION = (2, 0, 1, "final", 0)
+VERSION = (3, 0, 0, "final", 0)
 
 __title__ = "django-actistream"
 __version_info__ = VERSION
@@ -9,7 +9,7 @@ __version__ = ".".join(map(str, VERSION[:3])) + (
 )
 __author__ = "Raymond Penners"
 __license__ = "MIT"
-__copyright__ = "Copyright 2017-2022 Raymond Penners and contributors"
+__copyright__ = "Copyright 2017-2023 Raymond Penners and contributors"
 
 
 class ActivityTypeRegistry(object):

--- a/actistream/migrations/0003_rename_notice_user_read_at_notice.py
+++ b/actistream/migrations/0003_rename_notice_user_read_at_notice.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('actistream', '0002_notice_index_together'),
+    ]
+
+    operations = [
+        migrations.RenameIndex(
+            model_name='notice',
+            new_name='notice',
+            old_fields=('user', 'read_at'),
+        ),
+    ]

--- a/actistream/models.py
+++ b/actistream/models.py
@@ -167,7 +167,12 @@ class Notice(models.Model):
     class Meta:
         verbose_name = _("notice")
         verbose_name_plural = _("notices")
-        index_together = [["user", "read_at"]]
+        indexes = [
+            models.Index(
+                name="notice",
+                fields=("user", "read_at"),
+            ),
+        ]
 
 
 registry.load()

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        "django>=2.0",
+        "django>=2.1",
     ],
     cmdclass={"test": DjangoTests},
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,27 +1,27 @@
 [tox]
 distribute = False
 envlist =
-    py{35,36,37}-django20
     py{35,36,37}-django21
     py{35,36,37,38,39}-django22
     py{36,37,38,39}-django30
     py{36,37,38,39}-django31
     py{36,37,38,39}-django32
     py{38,39}-django40
-    py{39}-djangomaster
+    py{38,39,310,311}-django42
+    py{311}-djangomaster
 
 
 [testenv]
 setenv = DJANGO_SETTINGS_MODULE=actistream.tests.settings
 usedevelop = True
 deps =
-    django20: Django==2.0.*
     django21: Django==2.1.*
     django22: Django==2.2.*
     django30: Django==3.0.*
     django31: Django==3.1.*
     django32: Django==3.2.*
     django40: Django==4.0.*
+    django42: Django==4.2.*
     djangomaster: https://api.github.com/repos/django/django/tarball/master
     pytz
     coverage


### PR DESCRIPTION
- Raised the minimum required Django version to 2.1.
- Compatibility with Django 4.2.